### PR TITLE
Resolves Issue #55

### DIFF
--- a/algorithms/synchronization/synchronize.c
+++ b/algorithms/synchronization/synchronize.c
@@ -1,11 +1,16 @@
 #include<stdio.h>
 #include<pthread.h>
+
+pthread_mutex_t sum_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 long long sum=0;
 void* func(void* ptr)
 {
-	for(int i=0;i<10000;++i)
+	for(int i=0;i<10000;++i){
+        pthread_mutex_lock(&sum_mutex);
 		sum=sum+1;
-	
+        pthread_mutex_unlock(&sum_mutex);
+    }
 }
 int main()
 {

--- a/algorithms/synchronization/synchronize.c
+++ b/algorithms/synchronization/synchronize.c
@@ -6,7 +6,8 @@ pthread_mutex_t sum_mutex = PTHREAD_MUTEX_INITIALIZER;
 long long sum=0;
 void* func(void* ptr)
 {
-	for(int i=0;i<10000;++i){
+	for(int i=0;i<10000;++i)
+    {
         pthread_mutex_lock(&sum_mutex);
 		sum=sum+1;
         pthread_mutex_unlock(&sum_mutex);
@@ -21,7 +22,7 @@ int main()
 
 	for(int i=0;i<10;++i)
 		pthread_join(t1[i], NULL); 
-
+    pthread_mutex_destroy(&sum_mutex);
 	printf("%Ld",sum);
 	return 0;
 }


### PR DESCRIPTION
Resolves Issue #55 

### Description
Added a global mutex to ensure mutual exclusion during the critical section.

### How to run
Compile with `gcc -pthread synchronize.c`
Run with `./a.out`
Should output 100000.

### Checklist
- [ ✓] Code compiles correctly.
- [ ✓] Changes are tested properly.
- [ ?] Added the README / documentation, if necessary.
- [ ✓] Followed the Contributing guidelines.
- [✓ ] Resolved merge conflicts, if any.

Call to @Madhuparna04 to review PR.