### PR TITLE
oauth demo

### DIFF
--- a/development/OAuth_Cookies/README.md
+++ b/development/OAuth_Cookies/README.md
@@ -1,0 +1,41 @@
+This simple HTML site shows the use of OAuth2 in your web application.
+
+This is built using [gapi](https://github.com/google/google-api-javascript-client) but the 
+concepts related to oauth are the same.
+
+OAuth is an open standard for access delegation, commonly used as a way for Internet users to grant websites or applications access to their information on other websites but without giving them the passwords.
+
+OAuth does this by sharing a token to 3rd party application after authorization. This token can be used to access user's information according to the (scopes)[https://oauth.net/2/scope/] granted by 
+user.
+
+### oauth clients require following info
+
+* **clientId** The client id string assigned to you by the provider
+* **clientSecret** The client secret string assigned to you by the provider (not required for `token`)
+* **accessTokenUri** The url to request the access token (not required for `token`)
+* **authorizationUri** The url to redirect users to authenticate with the provider (only required for `token` and `code`)
+* **redirectUri** A custom url for the provider to redirect users back to your application (only required for `token` and `code`)
+* **scopes** An array of scopes to authenticate against
+* **state** Nonce sent back with the redirect when authorization is complete to verify authenticity (should be random for every request)
+
+
+In our example the clientId is to be given in meta tag with name 'google-signin-client_id'
+
+The authorizationUri is managed by gapi itself. 
+
+After authorization or signIn the gapi store the cookies in local Storage of your application's local address. In my case 'http://localhost:3002'
+
+To create webClient go to:
+(https://console.developers.google.com)[https://console.developers.google.com]
+create a new project
+in it's credentials section create OAuth Client ID of type Web application
+add authorized origin and redirect url according to your application
+eg, for this demo
+    origin: 	http://localhost:3002
+    redirect:    http://localhost:3002/auth_callback   
+
+To test this application serve the page on http://localhost:3002.
+eg, run 
+`$ npx serve -l 3002 ` in current directory   
+after clicking google signin the gapi authenticates using OAuth2 and stores the cookie sent from server in localstorage. Note that even after reloading or re-opening in different tabs the session is maintained because of cookies. Logout clears these cookies.
+

--- a/development/OAuth_Cookies/index.html
+++ b/development/OAuth_Cookies/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+    <!-- replace content with your own google project's clientId -->
+    <meta name="google-signin-client_id" content="<YOUR_CLIENT_ID.apps.googleusercontent.com>">
+    <title>oauthDemo</title>
+    <script src="https://apis.google.com/js/platform.js" async defer></script>
+</head>
+<body>
+    <div class="g-signin2" data-onsuccess="onSignIn"></div>
+    <script>
+        function onSignIn(googleUser) {
+            var profile = googleUser.getBasicProfile();
+            console.log('ID: ' + profile.getId()); // Do not send to your backend! Use an ID token instead.
+            console.log('Name: ' + profile.getName());
+            console.log('Image URL: ' + profile.getImageUrl());
+            console.log('Email: ' + profile.getEmail()); // This is null if the 'email' scope is not present.
+
+
+            document.querySelector('.g-signin2').style.visibility = 'hidden';
+            document.querySelector('#logout').style.visibility = 'visible';
+
+            document.querySelector('#info').innerText = JSON.stringify(profile,null,2)            
+        }
+    </script>
+
+    <div id='info'></div>
+
+    <a href="#" id='logout' style="visibility: hidden" onclick="signOut();">Sign out</a>
+    <script>
+    function signOut() {
+
+        
+        var auth2 = gapi.auth2.getAuthInstance();
+        auth2.signOut().then(function () {
+            console.log('User signed out.');
+            document.querySelector('.g-signin2').style.visibility = 'visible';
+            document.querySelector('#logout').style.visibility = 'hidden';
+            document.querySelector('#info').innerText = ''
+        });
+    }
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
Resolves Issue #229 

### Description
Implementation of social OAuth for google signin.
Added the directory structure and files required.

### Technical Specifications
Implemented simple demo for `OAuth` using `gapi` that demonstrates cookie based sessions.
Added short explanation of the flow.

### How to run
refer to `README.md`
create a google cloud project as directed and add the client ID  in index.html
run `$npx serve -l 3002` at the path `development/OAuth_Cookies/`

### Checklist
- [x] Code compiles correctly.
- [x] Changes are tested properly.
- [x] Added the README / documentation, if necessary.
- [x] Followed the Contributing guidelines.
- [x] Resolved merge conflicts, if any.
